### PR TITLE
fix namespace ignoring when console is invoked

### DIFF
--- a/src/Codeception/Command/Console.php
+++ b/src/Codeception/Command/Console.php
@@ -81,6 +81,7 @@ class Console extends Command
         $this->suite    = $suiteManager->getSuite();
 
         $scenario = new Scenario($this->test);
+        if (isset($config["namespace"])) $settings['class_name'] = $config["namespace"].'\\'.$settings['class_name'];
         $actor      = $settings['class_name'];
         $I        = new $actor($scenario);
 


### PR DESCRIPTION
`./codecept console accept` did not work when `namespace` attribute occured in codeception.yml file. Helper classes could not be in namespaces.
